### PR TITLE
Users can see favorites in profile

### DIFF
--- a/api/citiesModels/cities.js
+++ b/api/citiesModels/cities.js
@@ -1,5 +1,7 @@
 const Parse = require('parse/node')
 
+
+// Get current user
 class Cities {
     static async getUser() {
         Parse.User.enableUnsafeCurrentUser()

--- a/api/citiesModels/cities.js
+++ b/api/citiesModels/cities.js
@@ -1,0 +1,12 @@
+const Parse = require('parse/node')
+
+class Cities {
+    static async getUser() {
+        Parse.User.enableUnsafeCurrentUser()
+        const currentUser = await Parse.User.current();
+        return currentUser;
+    }
+}
+
+
+module.exports = Cities;

--- a/api/citiesRoutes/cities.js
+++ b/api/citiesRoutes/cities.js
@@ -3,6 +3,7 @@ const router  = express.Router();
 const Cities  = require("../citiesModels/cities")
 const Parse = require('parse/node')
 
+// Get list of favorited cities
 router.get("/", async (req, res, next) => {
     try {
         const user = await Cities.getUser();

--- a/api/citiesRoutes/cities.js
+++ b/api/citiesRoutes/cities.js
@@ -1,6 +1,17 @@
 const express = require("express");
 const router  = express.Router();
+const Cities  = require("../citiesModels/cities")
 const Parse = require('parse/node')
+
+router.get("/", async (req, res, next) => {
+    try {
+        const user = await Cities.getUser();
+        let cities = user.get("cities");
+        res.status(200).json({ cities })
+    } catch (err) {
+        next(err);
+    }
+})
 
 // Add route adds a city to the end of the "cities" array in the User object
 router.post('/add', async (req, res, next) => {

--- a/api/index.js
+++ b/api/index.js
@@ -3,7 +3,7 @@ const morgan = require('morgan')
 const cors = require('cors')
 const Parse = require('parse/node')
 const authRoute = require('./authentication/authentication')
-const citiesRoute = require('./cities/cities')
+const citiesRoute = require('./citiesRoutes/cities')
 //import Parse from 'parse/dist/parse.min.js';
 const {PARSE_APP_ID, PARSE_JAVASCRIPT_KEY} = require('./config')
 //const { default: App } = require('../ui/src/components/App/App')

--- a/ui/src/components/UserProfile/UserProfile.css
+++ b/ui/src/components/UserProfile/UserProfile.css
@@ -16,3 +16,7 @@
     margin-top: 100px;
     color: var(--dark-blue);
 }
+
+.favorites {
+    font-weight: bold;
+}

--- a/ui/src/components/UserProfile/UserProfile.jsx
+++ b/ui/src/components/UserProfile/UserProfile.jsx
@@ -16,7 +16,6 @@ export default function UserProfile({ user }) {
             const response = await axios.get(`http://localhost:3001/cities/`).catch((err)=>{
               console.error(err)
             })
-            console.log(response)
             setCities(response.data.cities);
           }
           setup();
@@ -29,7 +28,6 @@ export default function UserProfile({ user }) {
                     <Bootstrap.Card.Text className="favorites">Favorites</Bootstrap.Card.Text>
                     {
                     cities.map((city)=>{
-                        {console.log(city)}
                         return(<Bootstrap.Card.Text>{city}</Bootstrap.Card.Text>)
 
                     })}

--- a/ui/src/components/UserProfile/UserProfile.jsx
+++ b/ui/src/components/UserProfile/UserProfile.jsx
@@ -4,21 +4,40 @@ import axios from "axios"
 import * as config from '../../config'
 import * as Bootstrap from "react-bootstrap"
 import 'bootstrap/dist/css/bootstrap.min.css';
+import { useState, useEffect } from "react"
 
 
 export default function UserProfile({ user }) {
+    const [cities, setCities] = useState([])
+
     // Contains the users information in a Bootstrap Card component
+    React.useEffect(() => {
+        let setup = async()=>{
+            const response = await axios.get(`http://localhost:3001/cities/`).catch((err)=>{
+              console.error(err)
+            })
+            console.log(response)
+            setCities(response.data.cities);
+          }
+          setup();
+    }, [])
     return (
         <Bootstrap.Container>
             <Bootstrap.Card className="Card">
                <Bootstrap.Card.Body>
-                    <Bootstrap.Card.Title>{user?.username}</Bootstrap.Card.Title>
-                    <Bootstrap.Card.Text>Favorites go here</Bootstrap.Card.Text>
+                    <Bootstrap.Card.Title >{user?.username}</Bootstrap.Card.Title>
+                    <Bootstrap.Card.Text className="favorites">Favorites</Bootstrap.Card.Text>
+                    {
+                    cities.map((city)=>{
+                        {console.log(city)}
+                        return(<Bootstrap.Card.Text>{city}</Bootstrap.Card.Text>)
+
+                    })}
                     <Bootstrap.Card.Text>Friends go here</Bootstrap.Card.Text>
                </Bootstrap.Card.Body>
             </Bootstrap.Card>
         </Bootstrap.Container>
     )
 
-    
+
 }


### PR DESCRIPTION
In this commit, the user can now view cities that they've "starred" on their profile

Changes:
- Cities "models" directory to separate functions
- User can view favorites

Next steps:
- On load, make sure that application remembers cities that were favorited on last session
- Ability to add 'friends'

Callouts for Review:
- Should users be able to click on the city from their profile to view info about the city as an MVP feature or stretch feature?

Resources Used:
- N/A

Before:
<img width="1678" alt="Screen Shot 2022-07-20 at 3 05 53 PM" src="https://user-images.githubusercontent.com/35511922/180090754-3ed712c4-7d14-42f1-a9b3-bd40fdd85587.png">

After:
<img width="1676" alt="Screen Shot 2022-07-20 at 3 06 27 PM" src="https://user-images.githubusercontent.com/35511922/180090764-e037fad1-3d2b-4ea8-87fa-ab666cba8d6f.png">

